### PR TITLE
Bitflags take 2

### DIFF
--- a/codegen_tests/Cargo.lock
+++ b/codegen_tests/Cargo.lock
@@ -3,5 +3,14 @@
 version = 3
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "codegen_tests"
 version = "0.1.0"
+dependencies = [
+ "bitflags",
+]

--- a/codegen_tests/Cargo.toml
+++ b/codegen_tests/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [lib]
 name = "codegen_tests"
 path = "output/lib.rs"
+
+[dependencies]
+bitflags = "2.6"

--- a/codegen_tests/input/bitflags.pyxis
+++ b/codegen_tests/input/bitflags.pyxis
@@ -1,0 +1,6 @@
+pub bitflags TestBitflags: u32 {
+    NONE = 0,
+    FLAG_1 = 1,
+    FLAG_2 = 2,
+    FLAG_3 = 4,
+}

--- a/codegen_tests/input/bitflags.pyxis
+++ b/codegen_tests/input/bitflags.pyxis
@@ -4,3 +4,12 @@ pub bitflags TestBitflags: u32 {
     FLAG_2 = 2,
     FLAG_3 = 4,
 }
+
+#[defaultable]
+pub bitflags TestBitflags2: u32 {
+    NONE = 0,
+    FLAG_1 = 1,
+    #[default]
+    FLAG_2 = 2,
+    FLAG_3 = 4,
+}

--- a/codegen_tests/input/enums.pyxis
+++ b/codegen_tests/input/enums.pyxis
@@ -1,11 +1,3 @@
-#[defaultable, bitflags]
-pub enum TestBitflags: u32 {
-    NONE = 0,
-    FLAG_1 = 1,
-    FLAG_2 = 2,
-    FLAG_3 = 4,
-}
-
 #[defaultable]
 pub enum TestEnum: u32 {
     #[default]

--- a/codegen_tests/input/enums.pyxis
+++ b/codegen_tests/input/enums.pyxis
@@ -1,0 +1,15 @@
+#[defaultable, bitflags]
+pub enum TestBitflags: u32 {
+    NONE = 0,
+    FLAG_1 = 1,
+    FLAG_2 = 2,
+    FLAG_3 = 4,
+}
+
+#[defaultable]
+pub enum TestEnum: u32 {
+    #[default]
+    None,
+    Some,
+    Value,
+}

--- a/codegen_tests/output/bitflags.rs
+++ b/codegen_tests/output/bitflags.rs
@@ -1,0 +1,18 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    clippy::missing_safety_doc,
+    clippy::unnecessary_cast
+)]
+#![cfg_attr(any(), rustfmt::skip)]
+bitflags::bitflags! {
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Debug,)] pub struct TestBitflags : u32 {
+    const NONE = 0usize as _; const FLAG_1 = 1usize as _; const FLAG_2 = 2usize as _;
+    const FLAG_3 = 4usize as _; }
+}
+fn _TestBitflags_size_check() {
+    unsafe {
+        ::std::mem::transmute::<[u8; 0x4], TestBitflags>([0u8; 0x4]);
+    }
+    unreachable!()
+}

--- a/codegen_tests/output/bitflags.rs
+++ b/codegen_tests/output/bitflags.rs
@@ -16,3 +16,19 @@ fn _TestBitflags_size_check() {
     }
     unreachable!()
 }
+bitflags::bitflags! {
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Debug,)] pub struct TestBitflags2 : u32 {
+    const NONE = 0usize as _; const FLAG_1 = 1usize as _; const FLAG_2 = 2usize as _;
+    const FLAG_3 = 4usize as _; }
+}
+fn _TestBitflags2_size_check() {
+    unsafe {
+        ::std::mem::transmute::<[u8; 0x4], TestBitflags2>([0u8; 0x4]);
+    }
+    unreachable!()
+}
+impl Default for TestBitflags2 {
+    fn default() -> Self {
+        Self::FLAG_2
+    }
+}

--- a/codegen_tests/output/enums.rs
+++ b/codegen_tests/output/enums.rs
@@ -5,17 +5,6 @@
     clippy::unnecessary_cast
 )]
 #![cfg_attr(any(), rustfmt::skip)]
-bitflags::bitflags! {
-    #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Default)] pub struct TestBitflags :
-    u32 { const NONE = 0isize as _; const FLAG_1 = 1isize as _; const FLAG_2 = 2isize as
-    _; const FLAG_3 = 4isize as _; }
-}
-fn _TestBitflags_size_check() {
-    unsafe {
-        ::std::mem::transmute::<[u8; 0x4], TestBitflags>([0u8; 0x4]);
-    }
-    unreachable!()
-}
 #[repr(u32)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Default)]
 pub enum TestEnum {

--- a/codegen_tests/output/enums.rs
+++ b/codegen_tests/output/enums.rs
@@ -1,0 +1,32 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    clippy::missing_safety_doc,
+    clippy::unnecessary_cast
+)]
+#![cfg_attr(any(), rustfmt::skip)]
+bitflags::bitflags! {
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Default)] pub struct TestBitflags :
+    u32 { const NONE = 0isize as _; const FLAG_1 = 1isize as _; const FLAG_2 = 2isize as
+    _; const FLAG_3 = 4isize as _; }
+}
+fn _TestBitflags_size_check() {
+    unsafe {
+        ::std::mem::transmute::<[u8; 0x4], TestBitflags>([0u8; 0x4]);
+    }
+    unreachable!()
+}
+#[repr(u32)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Default)]
+pub enum TestEnum {
+    #[default]
+    None = 0isize as _,
+    Some = 1isize as _,
+    Value = 2isize as _,
+}
+fn _TestEnum_size_check() {
+    unsafe {
+        ::std::mem::transmute::<[u8; 0x4], TestEnum>([0u8; 0x4]);
+    }
+    unreachable!()
+}

--- a/codegen_tests/output/lib.rs
+++ b/codegen_tests/output/lib.rs
@@ -1,3 +1,4 @@
+pub mod bitflags;
 pub mod diamond_inheritance;
 pub mod doc_comments;
 pub mod enums;

--- a/codegen_tests/output/lib.rs
+++ b/codegen_tests/output/lib.rs
@@ -1,5 +1,6 @@
 pub mod diamond_inheritance;
 pub mod doc_comments;
+pub mod enums;
 pub mod multiple_levels;
 pub mod singleton;
 pub mod two_base_classes;

--- a/src/backends/rust.rs
+++ b/src/backends/rust.rs
@@ -411,7 +411,6 @@ fn build_enum(
         copyable,
         cloneable,
         defaultable,
-        bitflags,
         default_index,
     } = enum_definition;
 
@@ -458,26 +457,6 @@ fn build_enum(
         extra_derives.push(quote! { Default });
     }
 
-    if *bitflags {
-        let syn_fields = fields.iter().map(|(name, value)| {
-            let name_ident = str_to_ident(name);
-            quote! {
-                const #name_ident = #value as _;
-            }
-        });
-
-        Ok(quote! {
-            bitflags::bitflags! {
-                #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, #(#extra_derives),*)]
-                #doc
-                #visibility struct #name_ident: #syn_type {
-                    #(#syn_fields)*
-                }
-            }
-            #size_check_impl
-            #singleton_impl
-        })
-    } else {
         let syn_fields = fields.iter().enumerate().map(|(idx, (name, value))| {
             let name_ident = str_to_ident(name);
             let field = quote! {

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -219,6 +219,9 @@ impl Attribute {
     pub fn defaultable() -> Self {
         Attribute::Ident("defaultable".into())
     }
+    pub fn bitflags() -> Self {
+        Attribute::Ident("bitflags".into())
+    }
     #[allow(clippy::should_implement_trait)]
     pub fn default() -> Self {
         Attribute::Ident("default".into())

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -7,6 +7,8 @@ pub mod test_aliases {
     pub type TD = super::TypeDefinition;
     pub type ES = super::EnumStatement;
     pub type ED = super::EnumDefinition;
+    pub type BFS = super::BitflagsStatement;
+    pub type BFD = super::BitflagsDefinition;
     pub type T = super::Type;
     pub type A = super::Attribute;
     pub type As = super::Attributes;
@@ -397,6 +399,7 @@ impl From<(Ident, Expr)> for ExprField {
     }
 }
 
+// types
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TypeField {
     Field(Visibility, Ident, Type),
@@ -419,7 +422,6 @@ impl TypeField {
         matches!(self, TypeField::Vftable(_))
     }
 }
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TypeStatement {
     pub field: TypeField,
@@ -443,7 +445,6 @@ impl TypeStatement {
         self
     }
 }
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TypeDefinition {
     pub statements: Vec<TypeStatement>,
@@ -462,6 +463,7 @@ impl TypeDefinition {
     }
 }
 
+// enums
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EnumStatement {
     pub name: Ident,
@@ -487,7 +489,6 @@ impl EnumStatement {
         self
     }
 }
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EnumDefinition {
     pub type_: Type,
@@ -512,10 +513,59 @@ impl EnumDefinition {
     }
 }
 
+// bitflags
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BitflagsStatement {
+    pub name: Ident,
+    pub expr: Expr,
+    pub attributes: Attributes,
+}
+impl BitflagsStatement {
+    pub fn new(name: Ident, expr: Expr) -> BitflagsStatement {
+        BitflagsStatement {
+            name,
+            expr,
+            attributes: Default::default(),
+        }
+    }
+    pub fn field(name: &str, expr: Expr) -> BitflagsStatement {
+        Self::new(name.into(), expr)
+    }
+    pub fn with_attributes(mut self, attributes: impl Into<Attributes>) -> Self {
+        self.attributes = attributes.into();
+        self
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BitflagsDefinition {
+    pub type_: Type,
+    pub statements: Vec<BitflagsStatement>,
+    pub attributes: Attributes,
+}
+impl BitflagsDefinition {
+    pub fn new(
+        type_: Type,
+        statements: impl Into<Vec<BitflagsStatement>>,
+        attributes: impl Into<Attributes>,
+    ) -> Self {
+        Self {
+            type_,
+            statements: statements.into(),
+            attributes: attributes.into(),
+        }
+    }
+    pub fn with_attributes(mut self, attributes: impl Into<Attributes>) -> Self {
+        self.attributes = attributes.into();
+        self
+    }
+}
+
+// items
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ItemDefinitionInner {
     Type(TypeDefinition),
     Enum(EnumDefinition),
+    Bitflags(BitflagsDefinition),
 }
 impl From<TypeDefinition> for ItemDefinitionInner {
     fn from(item: TypeDefinition) -> Self {
@@ -525,6 +575,11 @@ impl From<TypeDefinition> for ItemDefinitionInner {
 impl From<EnumDefinition> for ItemDefinitionInner {
     fn from(item: EnumDefinition) -> Self {
         ItemDefinitionInner::Enum(item)
+    }
+}
+impl From<BitflagsDefinition> for ItemDefinitionInner {
+    fn from(item: BitflagsDefinition) -> Self {
+        ItemDefinitionInner::Bitflags(item)
     }
 }
 

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -219,9 +219,6 @@ impl Attribute {
     pub fn defaultable() -> Self {
         Attribute::Ident("defaultable".into())
     }
-    pub fn bitflags() -> Self {
-        Attribute::Ident("bitflags".into())
-    }
     #[allow(clippy::should_implement_trait)]
     pub fn default() -> Self {
         Attribute::Ident("default".into())

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -319,6 +319,36 @@ fn can_parse_enum() {
 }
 
 #[test]
+fn can_parse_bitflags() {
+    let text = r#"
+        #[singleton(0x1234)]
+        pub bitflags TestType: u32 {
+            #[default]
+            Item1 = 0b0001,
+            Item2 = 0b0010,
+            Item3 = 0b0100,
+            Item4 = 0b1000,
+        }
+        "#;
+
+    let ast = M::new().with_definitions([ID::new(
+        (V::Public, "TestType"),
+        BFD::new(
+            T::ident("u32"),
+            [
+                BFS::field("Item1", E::IntLiteral(0b0001)).with_attributes([A::default()]),
+                BFS::field("Item2", E::IntLiteral(0b0010)),
+                BFS::field("Item3", E::IntLiteral(0b0100)),
+                BFS::field("Item4", E::IntLiteral(0b1000)),
+            ],
+            [A::singleton(0x1234)],
+        ),
+    )]);
+
+    assert_eq!(parse_str(text).unwrap(), ast);
+}
+
+#[test]
 fn can_parse_array_field() {
     let text = r#"
         pub type TestType {

--- a/src/semantic/enum_definition.rs
+++ b/src/semantic/enum_definition.rs
@@ -17,6 +17,7 @@ pub struct EnumDefinition {
     pub copyable: bool,
     pub cloneable: bool,
     pub defaultable: bool,
+    pub bitflags: bool,
     pub default_index: Option<usize>,
 }
 impl EnumDefinition {
@@ -29,6 +30,7 @@ impl EnumDefinition {
             copyable: false,
             cloneable: false,
             defaultable: false,
+            bitflags: false,
             default_index: None,
         }
     }
@@ -57,6 +59,10 @@ impl EnumDefinition {
     }
     pub fn with_defaultable(mut self, defaultable: bool) -> Self {
         self.defaultable = defaultable;
+        self
+    }
+    pub fn with_bitflags(mut self, bitflags: bool) -> Self {
+        self.bitflags = bitflags;
         self
     }
     pub fn with_default_index(mut self, default_index: usize) -> Self {
@@ -126,6 +132,7 @@ pub fn build(
     let mut copyable = false;
     let mut cloneable = false;
     let mut defaultable = false;
+    let mut bitflags = false;
     let doc = definition.attributes.doc(resolvee_path)?;
     for attribute in &definition.attributes {
         match attribute {
@@ -136,6 +143,7 @@ pub fn build(
                 }
                 "cloneable" => cloneable = true,
                 "defaultable" => defaultable = true,
+                "bitflags" => bitflags = true,
                 _ => {}
             },
             grammar::Attribute::Function(ident, exprs) => {
@@ -149,15 +157,19 @@ pub fn build(
         }
     }
 
-    if defaultable && default_index.is_none() {
-        anyhow::bail!(
-            "enum `{resolvee_path}` is marked as defaultable but has no default variant set"
-        );
+    if bitflags && default_index.is_some() {
+        anyhow::bail!("enum `{resolvee_path}` has a default variant set but is marked as bitflags");
     }
 
     if !defaultable && default_index.is_some() {
         anyhow::bail!(
             "enum `{resolvee_path}` has a default variant set but is not marked as defaultable"
+        );
+    }
+
+    if !bitflags && defaultable && default_index.is_none() {
+        anyhow::bail!(
+            "enum `{resolvee_path}` is marked as defaultable but has no default variant set"
         );
     }
 
@@ -173,6 +185,7 @@ pub fn build(
             singleton,
             copyable,
             cloneable,
+            bitflags,
             defaultable,
             default_index,
         }

--- a/src/semantic/enum_definition.rs
+++ b/src/semantic/enum_definition.rs
@@ -17,7 +17,6 @@ pub struct EnumDefinition {
     pub copyable: bool,
     pub cloneable: bool,
     pub defaultable: bool,
-    pub bitflags: bool,
     pub default_index: Option<usize>,
 }
 impl EnumDefinition {
@@ -30,7 +29,6 @@ impl EnumDefinition {
             copyable: false,
             cloneable: false,
             defaultable: false,
-            bitflags: false,
             default_index: None,
         }
     }
@@ -59,10 +57,6 @@ impl EnumDefinition {
     }
     pub fn with_defaultable(mut self, defaultable: bool) -> Self {
         self.defaultable = defaultable;
-        self
-    }
-    pub fn with_bitflags(mut self, bitflags: bool) -> Self {
-        self.bitflags = bitflags;
         self
     }
     pub fn with_default_index(mut self, default_index: usize) -> Self {
@@ -132,7 +126,6 @@ pub fn build(
     let mut copyable = false;
     let mut cloneable = false;
     let mut defaultable = false;
-    let mut bitflags = false;
     let doc = definition.attributes.doc(resolvee_path)?;
     for attribute in &definition.attributes {
         match attribute {
@@ -143,7 +136,6 @@ pub fn build(
                 }
                 "cloneable" => cloneable = true,
                 "defaultable" => defaultable = true,
-                "bitflags" => bitflags = true,
                 _ => {}
             },
             grammar::Attribute::Function(ident, exprs) => {
@@ -157,17 +149,13 @@ pub fn build(
         }
     }
 
-    if bitflags && default_index.is_some() {
-        anyhow::bail!("enum `{resolvee_path}` has a default variant set but is marked as bitflags");
-    }
-
     if !defaultable && default_index.is_some() {
         anyhow::bail!(
             "enum `{resolvee_path}` has a default variant set but is not marked as defaultable"
         );
     }
 
-    if !bitflags && defaultable && default_index.is_none() {
+    if defaultable && default_index.is_none() {
         anyhow::bail!(
             "enum `{resolvee_path}` is marked as defaultable but has no default variant set"
         );
@@ -185,7 +173,6 @@ pub fn build(
             singleton,
             copyable,
             cloneable,
-            bitflags,
             defaultable,
             default_index,
         }

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -1,5 +1,6 @@
 pub mod types;
 
+mod bitflags_definition;
 mod enum_definition;
 mod function;
 mod module;

--- a/src/semantic/semantic_state.rs
+++ b/src/semantic/semantic_state.rs
@@ -6,7 +6,7 @@ use crate::{
     grammar::{self, ItemPath},
     parser,
     semantic::{
-        enum_definition,
+        bitflags_definition, enum_definition,
         module::Module,
         type_definition,
         type_registry::TypeRegistry,
@@ -224,6 +224,9 @@ impl SemanticState {
                     }
                     grammar::ItemDefinitionInner::Enum(e) => {
                         enum_definition::build(&self, resolvee_path, e)?
+                    }
+                    grammar::ItemDefinitionInner::Bitflags(b) => {
+                        bitflags_definition::build(&self, resolvee_path, b)?
                     }
                 };
 

--- a/src/semantic/semantic_state.rs
+++ b/src/semantic/semantic_state.rs
@@ -11,8 +11,8 @@ use crate::{
         type_definition,
         type_registry::TypeRegistry,
         types::{
-            ExternValue, ItemCategory, ItemDefinition, ItemState, ItemStateResolved, Type,
-            TypeDefinition, Visibility,
+            ExternValue, ItemCategory, ItemDefinition, ItemState, ItemStateResolved,
+            PredefinedItem, Type, TypeDefinition, Visibility,
         },
     },
 };
@@ -34,26 +34,9 @@ impl SemanticState {
             .modules
             .insert(ItemPath::empty(), Module::default());
 
-        // Insert all of our predefined types.
-        let predefined_types = [
-            ("void", 0),
-            ("bool", 1),
-            ("u8", 1),
-            ("u16", 2),
-            ("u32", 4),
-            ("u64", 8),
-            ("u128", 16),
-            ("i8", 1),
-            ("i16", 2),
-            ("i32", 4),
-            ("i64", 8),
-            ("i128", 16),
-            ("f32", 4),
-            ("f64", 8),
-        ];
-
-        for (name, size) in predefined_types {
-            let path = ItemPath::from(name);
+        for predefined_item in PredefinedItem::ALL {
+            let path = ItemPath::from(predefined_item.name());
+            let size = predefined_item.size();
             let alignment = size.max(1);
             semantic_state
                 .add_item(ItemDefinition {
@@ -69,6 +52,7 @@ impl SemanticState {
                             .into(),
                     }),
                     category: ItemCategory::Predefined,
+                    predefined: Some(*predefined_item),
                 })
                 .expect("failed to add predefined type");
         }
@@ -144,6 +128,7 @@ impl SemanticState {
                 path: new_path,
                 state: ItemState::Unresolved(definition.clone()),
                 category: ItemCategory::Defined,
+                predefined: None,
             })?;
         }
 
@@ -190,6 +175,7 @@ impl SemanticState {
                     inner: TypeDefinition::default().into(),
                 }),
                 category: ItemCategory::Extern,
+                predefined: None,
             })?;
         }
 

--- a/src/semantic/tests/mod.rs
+++ b/src/semantic/tests/mod.rs
@@ -903,8 +903,7 @@ fn can_handle_defaultable_on_enum_with_default_field() {
                 (4, 4),
                 SED::new(ST::raw("u32"))
                     .with_fields([("Item1", 0), ("Item2", 1)])
-                    .with_defaultable(true)
-                    .with_default_index(1),
+                    .with_default(1),
             ),
         )],
     );
@@ -1067,7 +1066,7 @@ fn can_resolve_bitflags() {
 }
 
 #[test]
-fn defaultable_bitflags_are_rejected() {
+fn bitflags_handle_defaultable_correctly() {
     assert_ast_produces_failure(
         M::new().with_definitions([ID::new(
             (V::Public, "TestType"),
@@ -1081,7 +1080,7 @@ fn defaultable_bitflags_are_rejected() {
             )
             .with_attributes([A::defaultable()]),
         )]),
-        "defaultable was specified for bitflags `test::TestType`, but bitflags do not support defaults",
+        "bitflags `test::TestType` is marked as defaultable but has no default value set",
     );
 
     assert_ast_produces_failure(
@@ -1097,7 +1096,31 @@ fn defaultable_bitflags_are_rejected() {
             )
             .with_attributes([]),
         )]),
-        "default was specified for field `Item2` of bitflags `test::TestType`, but bitflags do not support defaults",
+        "bitflags `test::TestType` has a default value set but is not marked as defaultable",
+    );
+
+    assert_ast_produces_type_definitions(
+        M::new().with_definitions([ID::new(
+            (V::Public, "TestType"),
+            BFD::new(
+                T::ident("u32"),
+                [
+                    BFS::field("Item1", E::IntLiteral(0b0001)),
+                    BFS::field("Item2", E::IntLiteral(0b0010)).with_attributes([A::default()]),
+                ],
+                [],
+            )
+            .with_attributes([A::defaultable()]),
+        )]),
+        [SID::defined_resolved(
+            (SV::Public, "test::TestType"),
+            SISR::new(
+                (4, 4),
+                SBFD::new(ST::raw("u32"))
+                    .with_fields([("Item1", 0b0001), ("Item2", 0b0010)])
+                    .with_default(1),
+            ),
+        )],
     );
 }
 

--- a/src/semantic/type_definition/vftable.rs
+++ b/src/semantic/type_definition/vftable.rs
@@ -232,6 +232,7 @@ fn build_type(
             .into(),
         }),
         category: ItemCategory::Defined,
+        predefined: None,
     })
 }
 

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -195,8 +195,8 @@ impl ItemDefinitionInner {
     pub fn defaultable(&self) -> bool {
         match self {
             ItemDefinitionInner::Type(td) => td.defaultable,
-            ItemDefinitionInner::Enum(ed) => ed.defaultable && ed.default_index.is_some(),
-            ItemDefinitionInner::Bitflags(_bd) => false,
+            ItemDefinitionInner::Enum(ed) => ed.default.is_some(),
+            ItemDefinitionInner::Bitflags(bd) => bd.default.is_some(),
         }
     }
     pub fn as_type(&self) -> Option<&TypeDefinition> {

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 pub use crate::semantic::{
+    bitflags_definition::BitflagsDefinition,
     enum_definition::EnumDefinition,
     function::{Argument, CallingConvention, Function, FunctionBody},
     type_definition::{Region, TypeDefinition, TypeVftable},
@@ -16,6 +17,7 @@ pub mod test_aliases {
     pub type SID = super::ItemDefinition;
     pub type STD = super::TypeDefinition;
     pub type SED = super::EnumDefinition;
+    pub type SBFD = super::BitflagsDefinition;
     pub type ST = super::Type;
     pub type SAr = super::Argument;
     pub type SF = super::Function;
@@ -123,6 +125,12 @@ impl Type {
             Type::Function(_, _, _) => "a function",
         }
     }
+    pub fn as_raw(&self) -> Option<&ItemPath> {
+        match self {
+            Self::Raw(v) => Some(v),
+            _ => None,
+        }
+    }
 }
 impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -166,6 +174,7 @@ impl fmt::Display for Type {
 pub enum ItemDefinitionInner {
     Type(TypeDefinition),
     Enum(EnumDefinition),
+    Bitflags(BitflagsDefinition),
 }
 impl From<TypeDefinition> for ItemDefinitionInner {
     fn from(td: TypeDefinition) -> Self {
@@ -177,11 +186,17 @@ impl From<EnumDefinition> for ItemDefinitionInner {
         ItemDefinitionInner::Enum(ed)
     }
 }
+impl From<BitflagsDefinition> for ItemDefinitionInner {
+    fn from(bd: BitflagsDefinition) -> Self {
+        ItemDefinitionInner::Bitflags(bd)
+    }
+}
 impl ItemDefinitionInner {
     pub fn defaultable(&self) -> bool {
         match self {
             ItemDefinitionInner::Type(td) => td.defaultable,
             ItemDefinitionInner::Enum(ed) => ed.defaultable && ed.default_index.is_some(),
+            ItemDefinitionInner::Bitflags(_bd) => false,
         }
     }
     pub fn as_type(&self) -> Option<&TypeDefinition> {
@@ -200,12 +215,14 @@ impl ItemDefinitionInner {
         match self {
             ItemDefinitionInner::Type(_) => "a type",
             ItemDefinitionInner::Enum(_) => "an enum",
+            ItemDefinitionInner::Bitflags(_) => "a bitflags",
         }
     }
     pub fn doc(&self) -> Option<&str> {
         match self {
             ItemDefinitionInner::Type(t) => t.doc(),
             ItemDefinitionInner::Enum(e) => e.doc(),
+            ItemDefinitionInner::Bitflags(b) => b.doc(),
         }
     }
 }

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -244,12 +244,56 @@ pub enum ItemCategory {
     Extern,
 }
 
+macro_rules! predefined_items {
+    ($(($variant:ident, $name:expr, $size:expr)),* $(,)?) => {
+        #[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
+        pub enum PredefinedItem {
+            $($variant),*
+        }
+        impl PredefinedItem {
+            pub const ALL: &'static [PredefinedItem] = &[
+                $(Self::$variant),*
+            ];
+            pub fn name(&self) -> &'static str {
+                match self {
+                    $(Self::$variant => $name),*
+                }
+            }
+            pub fn size(&self) -> usize {
+                match self {
+                    $(Self::$variant => $size),*
+                }
+            }
+            pub fn is_unsigned_integer(&self) -> bool {
+                matches!(self, Self::U8 | Self::U16 | Self::U32 | Self::U64 | Self::U128)
+            }
+        }
+    }
+}
+predefined_items! {
+    (Void, "void", 0),
+    (Bool, "bool", 1),
+    (U8, "u8", 1),
+    (U16, "u16", 2),
+    (U32, "u32", 4),
+    (U64, "u64", 8),
+    (U128, "u128", 16),
+    (I8, "i8", 1),
+    (I16, "i16", 2),
+    (I32, "i32", 4),
+    (I64, "i64", 8),
+    (I128, "i128", 16),
+    (F32, "f32", 4),
+    (F64, "f64", 8),
+}
+
 #[derive(PartialEq, Eq, Debug, Clone, Hash)]
 pub struct ItemDefinition {
     pub visibility: Visibility,
     pub path: ItemPath,
     pub state: ItemState,
     pub category: ItemCategory,
+    pub predefined: Option<PredefinedItem>,
 }
 impl ItemDefinition {
     pub fn category_resolved(
@@ -262,6 +306,7 @@ impl ItemDefinition {
             path: path.into(),
             state: ItemState::Resolved(resolved),
             category,
+            predefined: None,
         }
     }
     pub fn defined_resolved(

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-PYXIS_TEST_POINTER_SIZE=4 cargo test "$@" && PYXIS_TEST_POINTER_SIZE=8 cargo test "$@"
-
+PYXIS_TEST_POINTER_SIZE=4 cargo test "$@" && PYXIS_TEST_POINTER_SIZE=8 cargo test "$@" && cargo run --example codegen_tests


### PR DESCRIPTION
Supersedes #39.

This implements bitflags as their own construct, `bitflags`, with their own rules / parsing / etc. This adds a bit more code, but it also means that bitflags don't have to share semantics with enums, especially as their code generation is quite different.

Thanks to @SK83RJOSH for kicking this off!